### PR TITLE
Tracking and displaying authentication profile patches

### DIFF
--- a/docs/tutorials/authentication.md
+++ b/docs/tutorials/authentication.md
@@ -1,10 +1,10 @@
 # Authentication
 
-There are multiple ways one can login to Synapse. We recommend users to choose the method that fits their workflow.
+There are multiple ways one can login to Synapse. We recommend users choose the method that fits their workflow best.
 
 ## Prerequisites
 
-* Create a [Personal Access Token](https://help.synapse.org/docs/Managing-Your-Account.2055405596.html#ManagingYourAccount-PersonalAccessTokens) (**aka: Synapse Auth Token**) token obtained
+* Create a [Personal Access Token](https://help.synapse.org/docs/Managing-Your-Account.2055405596.html#ManagingYourAccount-PersonalAccessTokens) (**aka: Synapse Auth Token**) obtained
 from synapse.org under your Settings.
     * Note that a token must minimally have the **view** scope to be used with the Synapse Python Client.
     * Include **Download** and **Modify** permissions if you are using the Synapse Python Client to follow any subsequent tutorials.
@@ -19,7 +19,7 @@ Use the [synapseclient.login][synapseclient.Synapse.login] function
 ```python
 import synapseclient
 syn = synapseclient.login(authToken="authtoken")
-#returns Welcome, First Last! 
+#returns Welcome, First Last!
 ```
 
 ### Command Line Client
@@ -38,103 +38,82 @@ Logged in as: username (1234567)
 
 For writing code using the Synapse Python client that is easy to share with others, please do not include your credentials in the code. Instead, please use the `~/.synapseConfig` file to manage your credentials.
 
-The Synapse Python Client supports multiple profiles within the ~/.synapseConfig file, enabling users to manage credentials for multiple accounts.
-
-Each profile is defined in its own `[profile <profile_name>]` section. A default profile can still be defined using '`[default]`.
+The Synapse Python Client supports multiple profiles within the `~/.synapseConfig` file, enabling users to manage credentials for multiple accounts. Each profile is defined in its own `[profile <profile_name>]` section. A default profile can still be defined using `[default]`.
 
 When installing the Synapse Python client, the `~/.synapseConfig` is added to your home directory.
 
 ### Automatically modifying the `~/.synapseConfig` file with the Command line Client
 You may modify the `~/.synapseConfig` file by utilizing the [command line client command and following the interactive prompts](./command_line_client.md#config):
 
+#### Modifying the synapse config for multiple profiles
+
 <!-- termynal -->
 ```
-#For modifying the username used in the default profile
-> synapse --profile default config
+> synapse config
+
 Synapse username (Optional): $MY_USERNAME
 
 Auth token: $MY_SYNAPSE_TOKEN
 
-#For adding a new profile with a new username
+Configuration profile name (Optional, 'default' used if not specified): $MY_CONFIG_PROFILE
+```
+
+#### Adding or updating a specific profile passed in as a command line argument
+<!-- termynal -->
+```
 > synapse --profile $MY_PROFILE_NAME config
+
 Synapse username (Optional): $MY_USERNAME
 
 Auth token: $MY_SYNAPSE_TOKEN
 ```
 
-Note: If you encounter a PermissionError 
-(e.g., [Errno 13] Permission denied: '/Users/username/.synapseConfig'), it is likely that the user does not have write permissions to the ~/.synapseConfig file. 
-To resolve this, ensure that you have the necessary permissions to modify this file. 
+Note: If you encounter a PermissionError
+(e.g., `[Errno 13] Permission denied: '/Users/username/.synapseConfig'`), it is likely that the user does not have write permissions to the `~/.synapseConfig` file.
+To resolve this, ensure that you have the necessary permissions to modify this file.
 You can change the permissions using the following command:
 
-<!-- termynal -->
-```
-chmod u+w ~/.synapseConfig
-```
+`chmod u+w ~/.synapseConfig`
 
 
 ### Manually modifying the `~/.synapseConfig` file
 The following describes how to add your credentials to the `~/.synapseConfig` file without the use of the `synapse config` command.
 
-Open the `~/.synapseConfig` file using your preferred text editing tool and find the following section:
+Open the `~/.synapseConfig` file using your preferred text editing tool and find/insert the following section(s):
 
 ```
-#[default]
+[default]
+username = default_user
+authtoken = default_auth_token
+
+[profile user1]
+username = user1
+authtoken = user1_auth_token
+
+[profile user2]
+username = user2
+authtoken = user2_auth_token
+
+# This section is deprecated. It will be used if a `default` profile or a specific profile is not present in the config file
+#[authentication]
 #username = default_user
 #authtoken = default_auth_token
-
-#[profile user1]
-#username = user1
-#authtoken = user1_auth_token
-
-#[profile user2]
-#username = user2
-#authtoken = user2_auth_token
 ```
 
-To enable this section, uncomment it. You don't need to specify your username when using authtoken as a pair, but if you do, it will be used to verify your identity. A personal access token generated from your synapse.org Settings can be used as your .synapseConfig authtoken.
+`username` is optional when using `authtoken`, but if provided, an additional check to verify the `authtoken` matches the `username` is performed.
 
-If logging in without specifying any profiles, it will default to the default profile.
-
-Now, you can login without specifying any arguments:
-
-```python
-import synapseclient
-syn = synapseclient.login()
-```
-<!-- termynal -->
-```
-#For default login 
-synapse login
-#returns Welcome, last first! 
-```
-
-If logging in specifying the profile, it will log in with said profile,
-or, if you are logging into a specific profile, simply pass the profile name as an argument to `login()`:
-
-```python
-import synapseclient
-syn = synapseclient.login(profile="user1")
-```
-
-<!-- termynal -->
-```
-#For profile login
-synapse login --profile <profile_name>
-#returns Welcome, last first! You are using the '<profile_name> profile. 
-```
-
+The `authoken` is also know as a personal access token. It is generated from your [synapse.org Settings](https://help.synapse.org/docs/Managing-Your-Account.2055405596.html#ManagingYourAccount-PersonalAccessTokens)..
 
 ### Transitioning from One Profile to Multiple
 
-If you're currently using a single profile (under the [default] section) and wish to start using multiple profiles, 
-simply add new sections for each profile with a unique profile name. For example, you can add a profile for user1 and user2 as shown below. 
+If you're currently using a single profile (under the `[default]` or `[authentication]` section) and wish to start using multiple profiles,
+simply add new sections for each profile with a unique profile name. For example, you can add a profile for user1 and user2 as shown below.
 The Synapse Python client will allow you to choose which profile to use at login.
 
 ```
-[authentication]
+[default]
 username = default_user
-#authtoken = default_auth_token
+authtoken = default_auth_token
 
 [profile user1]
 username = user1
@@ -145,7 +124,46 @@ username = user2
 authtoken = user2_auth_token
 ```
 
-When you add a new profile section like this, you can then use the --profile flag to specify which profile you want to log in under.
+## Logging in with your ~/.synapseConfig file
+
+**Note:** If no profile is specified the `default` section will be used. Additionally, to support backwards compatibility, `authentication` will continue to function. `authentication` will be used if no profile is used and `default` is not present in the configuration file.
+
+### Logging in via python code
+
+```python
+import synapseclient
+syn = synapseclient.login()
+```
+
+If you want to log in with a specific profile, simply pass the profile name as an argument to `login()`:
+
+```python
+import synapseclient
+syn = synapseclient.login(profile="user1")
+```
+
+### Logging in via the command line
+
+Logs in with the `default` profile, or the profile set in the `SYNAPSE_PROFILE` environment variable:
+
+<!-- termynal -->
+```
+#For default login
+> synapse login
+
+returns Welcome, last first!
+```
+
+Logging in with the `profile_name` given:
+
+<!-- termynal -->
+```
+#For profile login
+
+> synapse --profile profile_name login
+
+Welcome, last first! You are using the 'profile_name' profile.
+```
 
 ## Use Environment Variable
 
@@ -159,14 +177,16 @@ In your shell, you can pass an environment variable to Python inline by defining
 SYNAPSE_AUTH_TOKEN='<my_personal_access_token>' python3
 ```
 
-Alternatively you may export it first, then start: Python
+Alternatively you may export it first, then start Python:
 
 ```bash
 export SYNAPSE_AUTH_TOKEN='<my_personal_access_token>'
 python3
 ```
 
-Once you are inside Python, you may simply login without passing any arguments, or pass a profile argument to access a specific profile :
+Setting the `SYNAPSE_PROFILE` environment variable will allow you to log into Synapse using a specific authentication profile present in your `.synapseConfig` file. This allows you to have multiple profiles present in a single configuration file that you may swap between. Alternatively, you may use the `profile` parameter in Python, or the `--profile` command line flag for all commands like `synapse --profile <profile_name> COMMAND`.
+
+Once you are inside Python, you may simply login without passing any arguments, or pass a profile argument to access a specific profile:
 
 ```python
 import synapseclient
@@ -176,7 +196,7 @@ import synapseclient
 syn = synapseclient.login(profile="user1")
 ```
 
-To use the environment variable with the command line client, simply substitute `python` for the `synapse` command
+To use the environment variable with the command line client, simply substitute `python` for the `synapse` command:
 
 ```bash
 SYNAPSE_AUTH_TOKEN='<my_personal_access_token>' synapse get syn123

--- a/docs/tutorials/command_line_client.md
+++ b/docs/tutorials/command_line_client.md
@@ -17,7 +17,7 @@ For help on specific commands, type:
 ```bash
 synapse [command] -h
 ```
-Note: All commands support the --profile (or -r) flag to specify which Synapse profile to use from your ~/.synapseConfig file. If not specified, the default profile is used.
+**Note:** All commands support the --profile (or -r) flag to specify which Synapse profile to use from your ~/.synapseConfig file. If not specified, the default profile is used.
 
 Test your login credentials with an auth token environment variable:
 <!-- termynal -->
@@ -32,24 +32,24 @@ The usage is as follows:
 
 ```bash
 synapse [-h] [--version] [-u SYNAPSEUSER] [-p SYNAPSE_AUTH_TOKEN] [-c CONFIGPATH] [--debug] [--silent] [-s]
-        [--otel {console,otlp}]
+        [--otel {console,otlp}] [--profile SYNAPSE_CONFIG_PROFILE]
         {get,manifest,sync,store,add,mv,cp,get-download-list,associate,delete,query,submit,show,cat,list,config,set-provenance,get-provenance,set-annotations,get-annotations,create,store-table,onweb,login,test-encoding,get-sts-token,migrate}
         ...
 ```
 
 ## Options
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `--version`         | Flag    | Show program’s version number and exit                                    |                       |
-| `-u, --username`    | Option  | Username used to connect to Synapse                                       |                       |
-| `-p, --password`    | Option  | Auth Token used to connect to Synapse                                     |                       |
-| `-r, --profile`     | Option  | Name of the Synapse profile to use (from ~/.synapseConfig). Defaults to 'default'. | 'default'           |
-| `-c, --configPath`  | Option  | Path to configuration file used to connect to Synapse                     | “~/.synapseConfig”    |
-| `--debug`           | Flag    | Set to debug mode, additional output and error messages are printed to the console | False             |
-| `--silent`          | Flag    | Set to silent mode, console output is suppressed                          | False                 |
-| `-s, --skip-checks` | Flag    | Suppress checking for version upgrade messages and endpoint redirection   | False                 |
-| `--otel`            | Option  | Enable the usage of OpenTelemetry for tracing. Possible choices: console, otlp |                     |
+| Name                | Type   | Description                                                                        | Default            |
+|---------------------|--------|------------------------------------------------------------------------------------|--------------------|
+| `--version`         | Flag   | Show program’s version number and exit                                             |                    |
+| `-u, --username`    | Option | Username used to connect to Synapse                                                |                    |
+| `-p, --password`    | Option | Auth Token used to connect to Synapse                                              |                    |
+| `-r, --profile`     | Option | Name of the Synapse profile to use (from ~/.synapseConfig). Defaults to 'default'. | 'default'          |
+| `-c, --configPath`  | Option | Path to configuration file used to connect to Synapse                              | “~/.synapseConfig” |
+| `--debug`           | Flag   | Set to debug mode, additional output and error messages are printed to the console | False              |
+| `--silent`          | Flag   | Set to silent mode, console output is suppressed                                   | False              |
+| `-s, --skip-checks` | Flag   | Suppress checking for version upgrade messages and endpoint redirection            | False              |
+| `--otel`            | Option | Enable the usage of OpenTelemetry for tracing. Possible choices: console, otlp     |                    |
 
 ## Subcommands
 
@@ -92,17 +92,17 @@ synapse get [-h] [-q queryString] [-v VERSION] [-r] [--followLink] [--limitSearc
             [local path]
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `local path`        | Positional | Synapse ID of form syn123 of desired data object.                         |                       |
-| `-q, --query`       | Named  | Optional query parameter, will fetch all of the entities returned by a query. |                       |
-| `-v, --version`     | Named  | Synapse version number of entity to retrieve.                             | Most recent version   |
-| `-r, --recursive`   | Named  | Fetches content in Synapse recursively contained in the parentId specified by id. | False             |
-| `--followLink`      | Named  | Determines whether the link returns the target Entity.                    | False                 |
-| `--limitSearch`     | Named  | Synapse ID of a container such as project or folder to limit search for files if using a path. |                       |
-| `--downloadLocation`| Named  | Directory to download file to.                                            | “./”                  |
-| `--multiThreaded`   | Named  | Download file using a multiple threaded implementation.                   | True                  |
-| `--manifest`        | Named  | Determines whether creating manifest file automatically.                  | “all”                 |
+| Name                 | Type       | Description                                                                                    | Default             |
+|----------------------|------------|------------------------------------------------------------------------------------------------|---------------------|
+| `local path`         | Positional | Synapse ID of form syn123 of desired data object.                                              |                     |
+| `-q, --query`        | Named      | Optional query parameter, will fetch all of the entities returned by a query.                  |                     |
+| `-v, --version`      | Named      | Synapse version number of entity to retrieve.                                                  | Most recent version |
+| `-r, --recursive`    | Named      | Fetches content in Synapse recursively contained in the parentId specified by id.              | False               |
+| `--followLink`       | Named      | Determines whether the link returns the target Entity.                                         | False               |
+| `--limitSearch`      | Named      | Synapse ID of a container such as project or folder to limit search for files if using a path. |                     |
+| `--downloadLocation` | Named      | Directory to download file to.                                                                 | “./”                |
+| `--multiThreaded`    | Named      | Download file using a multiple threaded implementation.                                        | True                |
+| `--manifest`         | Named      | Determines whether creating manifest file automatically.                                       | “all”               |
 
 
 ### `manifest`
@@ -113,11 +113,11 @@ Generate manifest for uploading directory tree to Synapse.
 synapse manifest [-h] --parent-id syn123 [--manifest-file OUTPUT] PATH
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `PATH`              | Positional | A path to a file or folder whose manifest will be generated.              |                       |
-| `--parent-id`       | Named  | Synapse ID of project or folder where to upload data.                     |                       |
-| `--manifest-file`   | Named  | A TSV output file path where the generated manifest is stored.            | stdout                |
+| Name              | Type       | Description                                                    | Default |
+|-------------------|------------|----------------------------------------------------------------|---------|
+| `PATH`            | Positional | A path to a file or folder whose manifest will be generated.   |         |
+| `--parent-id`     | Named      | Synapse ID of project or folder where to upload data.          |         |
+| `--manifest-file` | Named      | A TSV output file path where the generated manifest is stored. | stdout  |
 
 
 ### `sync`
@@ -128,12 +128,12 @@ Synchronize files described in a manifest to Synapse.
 synapse sync [-h] [--dryRun] [--sendMessages] [--retries INT] FILE
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `FILE`              | Positional | A tsv file with file locations and metadata to be pushed to Synapse. See [synapseutils.sync.syncToSynapse][] for details on the format of a manifest. |                       |
-| `--dryRun`          | Named  | Perform validation without uploading.                                     | False                 |
-| `--sendMessages`    | Named  | Send notifications via Synapse messaging (email) at specific intervals, on errors and on completion. | False                 |
-| `--retries`         | Named  | Number of retries for failed uploads.                                     | 4                     |
+| Name             | Type       | Description                                                                                                                                           | Default |
+|------------------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `FILE`           | Positional | A tsv file with file locations and metadata to be pushed to Synapse. See [synapseutils.sync.syncToSynapse][] for details on the format of a manifest. |         |
+| `--dryRun`       | Named      | Perform validation without uploading.                                                                                                                 | False   |
+| `--sendMessages` | Named      | Send notifications via Synapse messaging (email) at specific intervals, on errors and on completion.                                                  | False   |
+| `--retries`      | Named      | Number of retries for failed uploads.                                                                                                                 | 4       |
 
 
 ### `store`
@@ -148,21 +148,21 @@ synapse store [-h] (--parentid syn123 | --id syn123 | --type TYPE) [--name NAME]
               [FILE]
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `FILE`              | Positional | File to be added to synapse.                                              |                       |
-| `--parentid, --parentId` | Named  | Synapse ID of project or folder where to upload data (must be specified if –id is not used). |                       |
-| `--id`              | Named  | Optional Id of entity in Synapse to be updated.                           |                       |
-| `--type`            | Named  | Type of object, such as “File”, “Folder”, or “Project”, to create in Synapse. | “File”               |
-| `--name`            | Named  | Name of data object in Synapse.                                           |                       |
-| `--description`     | Named  | Description of data object in Synapse.                                    |                       |
-| `--descriptionFile` | Named  | Path to a markdown file containing description of project/folder.          |                       |
-| `--used`            | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived. |                       |
-| `--executed`        | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |                       |
-| `--limitSearch`     | Named  | Synapse ID of a container such as project or folder to limit search for provenance files. |                       |
-| `--noForceVersion`  | Named  | Do not force a new version to be created if the contents of the file have not changed. | False                 |
-| `--annotations`     | Named  | Annotations to add as a JSON formatted string, should evaluate to a dictionary (key/value pairs). Example: ‘{“foo”: 1, “bar”:”quux”}’ |                       |
-| `--replace`         | Named  | Replace all existing annotations with the given annotations.                | False                 |
+| Name                     | Type       | Description                                                                                                                            | Default |
+|--------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `FILE`                   | Positional | File to be added to synapse.                                                                                                           |         |
+| `--parentid, --parentId` | Named      | Synapse ID of project or folder where to upload data (must be specified if –id is not used).                                           |         |
+| `--id`                   | Named      | Optional Id of entity in Synapse to be updated.                                                                                        |         |
+| `--type`                 | Named      | Type of object, such as “File”, “Folder”, or “Project”, to create in Synapse.                                                          | “File”  |
+| `--name`                 | Named      | Name of data object in Synapse.                                                                                                        |         |
+| `--description`          | Named      | Description of data object in Synapse.                                                                                                 |         |
+| `--descriptionFile`      | Named      | Path to a markdown file containing description of project/folder.                                                                      |         |
+| `--used`                 | Named      | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived.         |         |
+| `--executed`             | Named      | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |         |
+| `--limitSearch`          | Named      | Synapse ID of a container such as project or folder to limit search for provenance files.                                              |         |
+| `--noForceVersion`       | Named      | Do not force a new version to be created if the contents of the file have not changed.                                                 | False   |
+| `--annotations`          | Named      | Annotations to add as a JSON formatted string, should evaluate to a dictionary (key/value pairs). Example: ‘{“foo”: 1, “bar”:”quux”}’  |         |
+| `--replace`              | Named      | Replace all existing annotations with the given annotations.                                                                           | False   |
 
 
 ### `add`
@@ -176,21 +176,21 @@ synapse add [-h] (--parentid syn123 | --id syn123 | --type TYPE) [--name NAME]
             [FILE]
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `FILE`              | Positional | File to be added to synapse.                                              |                       |
-| `--parentid, --parentId` | Named  | Synapse ID of project or folder where to upload data (must be specified if –id is not used). |                       |
-| `--id`              | Named  | Optional Id of entity in Synapse to be updated.                           |                       |
-| `--type`            | Named  | Type of object, such as “File”, “Folder”, or “Project”, to create in Synapse. | “File”               |
-| `--name`            | Named  | Name of data object in Synapse.                                           |                       |
-| `--description`     | Named  | Description of data object in Synapse.                                    |                       |
-| `--descriptionFile` | Named  | Path to a markdown file containing description of project/folder.          |                       |
-| `--used`            | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived. |                       |
-| `--executed`        | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |                       |
-| `--limitSearch`     | Named  | Synapse ID of a container such as project or folder to limit search for provenance files. |                       |
-| `--noForceVersion`  | Named  | Do not force a new version to be created if the contents of the file have not changed. | False                 |
-| `--annotations`     | Named  | Annotations to add as a JSON formatted string, should evaluate to a dictionary (key/value pairs). Example: ‘{“foo”: 1, “bar”:”quux”}’ |                       |
-| `--replace`         | Named  | Replace all existing annotations with the given annotations.                | False                 |
+| Name                     | Type       | Description                                                                                                                            | Default |
+|--------------------------|------------|----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `FILE`                   | Positional | File to be added to synapse.                                                                                                           |         |
+| `--parentid, --parentId` | Named      | Synapse ID of project or folder where to upload data (must be specified if –id is not used).                                           |         |
+| `--id`                   | Named      | Optional Id of entity in Synapse to be updated.                                                                                        |         |
+| `--type`                 | Named      | Type of object, such as “File”, “Folder”, or “Project”, to create in Synapse.                                                          | “File”  |
+| `--name`                 | Named      | Name of data object in Synapse.                                                                                                        |         |
+| `--description`          | Named      | Description of data object in Synapse.                                                                                                 |         |
+| `--descriptionFile`      | Named      | Path to a markdown file containing description of project/folder.                                                                      |         |
+| `--used`                 | Named      | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived.         |         |
+| `--executed`             | Named      | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |         |
+| `--limitSearch`          | Named      | Synapse ID of a container such as project or folder to limit search for provenance files.                                              |         |
+| `--noForceVersion`       | Named      | Do not force a new version to be created if the contents of the file have not changed.                                                 | False   |
+| `--annotations`          | Named      | Annotations to add as a JSON formatted string, should evaluate to a dictionary (key/value pairs). Example: ‘{“foo”: 1, “bar”:”quux”}’  |         |
+| `--replace`              | Named      | Replace all existing annotations with the given annotations.                                                                           | False   |
 
 ### `mv`
 
@@ -200,10 +200,10 @@ Moves a file/folder in Synapse.
 synapse mv [-h] --id syn123 --parentid syn123
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `--id`              | Named  | Id of entity in Synapse to be moved.                                      |
-| `--parentid, --parentId` | Named  | Synapse ID of project or folder where file/folder will be moved.          |
+| Name                     | Type  | Description                                                      |
+|--------------------------|-------|------------------------------------------------------------------|
+| `--id`                   | Named | Id of entity in Synapse to be moved.                             |
+| `--parentid, --parentId` | Named | Synapse ID of project or folder where file/folder will be moved. |
 
 
 ### `cp`
@@ -216,16 +216,16 @@ synapse cp [-h] --destinationId syn123 [--version 1] [--setProvenance traceback]
            syn123
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `syn123`            | Positional | Id of entity in Synapse to be copied.                                     |                       |
-| `--destinationId`   | Named  | Synapse ID of project or folder where file will be copied to.              |                       |
-| `--version, -v`     | Named  | Synapse version number of File or Link to retrieve. This parameter cannot be used when copying Projects or Folders. Defaults to most recent version. | Most recent version |
-| `--setProvenance`   | Named  | Has three values to set the provenance of the copied entity-traceback: Sets to the source entityexisting: Sets to source entity’s original provenance (if it exists)None/none: No provenance is set | "traceback"         |
-| `--updateExisting`  | Named  | Will update the file if there is already a file that is named the same in the destination | False                 |
-| `--skipCopyAnnotations` | Named  | Do not copy the annotations                                               | False                 |
-| `--excludeTypes`    | Named  | Accepts a list of entity types (file, table, link) which determines which entity types to not copy. | []                    |
-| `--skipCopyWiki`    | Named  | Do not copy the wiki pages                                                 | False                 |
+| Name                    | Type       | Description                                                                                                                                                                                         | Default             |
+|-------------------------|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| `syn123`                | Positional | Id of entity in Synapse to be copied.                                                                                                                                                               |                     |
+| `--destinationId`       | Named      | Synapse ID of project or folder where file will be copied to.                                                                                                                                       |                     |
+| `--version, -v`         | Named      | Synapse version number of File or Link to retrieve. This parameter cannot be used when copying Projects or Folders. Defaults to most recent version.                                                | Most recent version |
+| `--setProvenance`       | Named      | Has three values to set the provenance of the copied entity-traceback: Sets to the source entityexisting: Sets to source entity’s original provenance (if it exists)None/none: No provenance is set | "traceback"         |
+| `--updateExisting`      | Named      | Will update the file if there is already a file that is named the same in the destination                                                                                                           | False               |
+| `--skipCopyAnnotations` | Named      | Do not copy the annotations                                                                                                                                                                         | False               |
+| `--excludeTypes`        | Named      | Accepts a list of entity types (file, table, link) which determines which entity types to not copy.                                                                                                 | []                  |
+| `--skipCopyWiki`        | Named      | Do not copy the wiki pages                                                                                                                                                                          | False               |
 
 ### `get-download-list`
 
@@ -235,9 +235,9 @@ Download files from the Synapse download cart.
 synapse get-download-list [-h] [--downloadLocation path]
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `--downloadLocation`| Named  | Directory to download file to.                                            | "./"                  |
+| Name                 | Type  | Description                    | Default |
+|----------------------|-------|--------------------------------|---------|
+| `--downloadLocation` | Named | Directory to download file to. | "./"    |
 
 ### `associate`
 
@@ -247,11 +247,11 @@ Associate local files with the files stored in Synapse so that calls to “synap
 synapse associate [-h] [--limitSearch projId] [-r] path
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `path`              | Positional | Local file path.                                                          |                       |
-| `--limitSearch`     | Named  | Synapse ID of a container such as project or folder to limit search to.    |                       |
-| `-r`                | Named  | Perform recursive association with all local files in a folder.            | False                 |
+| Name            | Type       | Description                                                             | Default |
+|-----------------|------------|-------------------------------------------------------------------------|---------|
+| `path`          | Positional | Local file path.                                                        |         |
+| `--limitSearch` | Named      | Synapse ID of a container such as project or folder to limit search to. |         |
+| `-r`            | Named      | Perform recursive association with all local files in a folder.         | False   |
 
 
 ### `delete`
@@ -262,10 +262,10 @@ Removes a dataset from Synapse.
 synapse delete [-h] [--version VERSION] syn123
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `syn123`            | Positional | Synapse ID of form syn123 of desired data object.                         |
-| `--version`         | Named  | Version number to delete of given entity.                                 |
+| Name        | Type       | Description                                       |
+|-------------|------------|---------------------------------------------------|
+| `syn123`    | Positional | Synapse ID of form syn123 of desired data object. |
+| `--version` | Named      | Version number to delete of given entity.         |
 
 
 ### `query`
@@ -276,9 +276,9 @@ Performs SQL like queries on Synapse.
 synapse query [-h] [string [string ...]]
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `string`            | Positional | A query string. Note that when using the command line query strings must be passed intact as a single string. In most shells this can mean wrapping the query in quotes as appropriate and escaping any quotes that may appear within the query string itself. Example: `synapse query "select \"column has spaces\" from syn123"`. See [Table Examples](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html) for more information. |
+| Name     | Type       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+|----------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `string` | Positional | A query string. Note that when using the command line query strings must be passed intact as a single string. In most shells this can mean wrapping the query in quotes as appropriate and escaping any quotes that may appear within the query string itself. Example: `synapse query "select \"column has spaces\" from syn123"`. See [Table Examples](https://rest-docs.synapse.org/rest/org/sagebionetworks/repo/web/controller/TableExamples.html) for more information. |
 
 
 ### `submit`
@@ -291,19 +291,19 @@ synapse submit [-h] [--evaluationID EVALUATIONID] [--evaluationName EVALUATIONNA
                [--executed [target [target ...]]] [--limitSearch projId]
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `--evaluationID, --evaluationId, --evalID` | Named  | Evaluation ID where the entity/file will be submitted.                    |
-| `--evaluationName, --evalN` | Named  | Evaluation Name where the entity/file will be submitted.                  |
-| `--entity, --eid, --entityId, --id` | Named  | Synapse ID of the entity to be submitted.                                 |
-| `--file, -f` | Named  | File to be submitted to the challenge.                                    |
-| `--parentId, --parentid, --parent` | Named  | Synapse ID of project or folder where to upload data.                     |
-| `--name` | Named  | Name of the submission.                                                    |
-| `--teamName, --team` | Named  | Submit on behalf of a registered team.                                    |
-| `--submitterAlias, --alias` | Named  | A nickname, possibly for display in leaderboards.                         |
-| `--used` | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived. |
-| `--executed` | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |
-| `--limitSearch` | Named  | Synapse ID of a container such as project or folder to limit search for provenance files. |
+| Name                                       | Type  | Description                                                                                                                            |
+|--------------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `--evaluationID, --evaluationId, --evalID` | Named | Evaluation ID where the entity/file will be submitted.                                                                                 |
+| `--evaluationName, --evalN`                | Named | Evaluation Name where the entity/file will be submitted.                                                                               |
+| `--entity, --eid, --entityId, --id`        | Named | Synapse ID of the entity to be submitted.                                                                                              |
+| `--file, -f`                               | Named | File to be submitted to the challenge.                                                                                                 |
+| `--parentId, --parentid, --parent`         | Named | Synapse ID of project or folder where to upload data.                                                                                  |
+| `--name`                                   | Named | Name of the submission.                                                                                                                |
+| `--teamName, --team`                       | Named | Submit on behalf of a registered team.                                                                                                 |
+| `--submitterAlias, --alias`                | Named | A nickname, possibly for display in leaderboards.                                                                                      |
+| `--used`                                   | Named | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived.         |
+| `--executed`                               | Named | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |
+| `--limitSearch`                            | Named | Synapse ID of a container such as project or folder to limit search for provenance files.                                              |
 
 ### `show`
 
@@ -313,10 +313,10 @@ Show metadata for an entity.
 synapse show [-h] [--limitSearch projId] syn123
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `syn123`            | Positional | Synapse ID of form syn123 of desired synapse object.                      |
-| `--limitSearch`     | Named  | Synapse ID of a container such as project or folder to limit search for provenance files. |
+| Name            | Type       | Description                                                                               |
+|-----------------|------------|-------------------------------------------------------------------------------------------|
+| `syn123`        | Positional | Synapse ID of form syn123 of desired synapse object.                                      |
+| `--limitSearch` | Named      | Synapse ID of a container such as project or folder to limit search for provenance files. |
 
 
 ### `cat`
@@ -327,10 +327,10 @@ Prints a dataset from Synapse.
 synapse cat [-h] [-v VERSION] syn123
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `syn123`            | Positional | Synapse ID of form syn123 of desired data object.                         |                       |
-| `-v, --version`     | Named  | Synapse version number of entity to display.                              | Most recent version   |
+| Name            | Type       | Description                                       | Default             |
+|-----------------|------------|---------------------------------------------------|---------------------|
+| `syn123`        | Positional | Synapse ID of form syn123 of desired data object. |                     |
+| `-v, --version` | Named      | Synapse version number of entity to display.      | Most recent version |
 
 
 ### `list`
@@ -341,12 +341,12 @@ List Synapse entities contained by the given Project or Folder. Note: May not be
 synapse list [-h] [-r] [-l] [-m] syn123
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `syn123`            | Positional | Synapse ID of a project or folder.                                        |                       |
-| `-r, --recursive`   | Named  | Recursively list contents of the subtree descending from the given Synapse ID. | False                 |
-| `-l, --long`        | Named  | List synapse entities in long format.                                     | False                 |
-| `-m, --modified`    | Named  | List modified by and modified date.                                       | False                 |
+| Name              | Type       | Description                                                                    | Default |
+|-------------------|------------|--------------------------------------------------------------------------------|---------|
+| `syn123`          | Positional | Synapse ID of a project or folder.                                             |         |
+| `-r, --recursive` | Named      | Recursively list contents of the subtree descending from the given Synapse ID. | False   |
+| `-l, --long`      | Named      | List synapse entities in long format.                                          | False   |
+| `-m, --modified`  | Named      | List modified by and modified date.                                            | False   |
 
 
 ### `config`
@@ -355,13 +355,17 @@ Create or modify a Synapse configuration file. This command interactively prompt
 Supports multiple profiles.
 
 ```bash
-synapse config [-h] [--profile PROFILE_NAME]
+synapse config [-h]
 ```
 
-| Name            | Type    | Description                                                               |
-|-----------------|---------|---------------------------------------------------------------------------|
-| `-h`            | Named  | Show the help message and exit.                                           |
-| `-r, --profile` | Named  |  Optional name of the Synapse profile to create or update in the config file. <br/>If omitted, modifies the `[default]` section.|
+```bash
+synapse --profile PROFILE_NAME config
+```
+
+| Name            | Type  | Description                                                                                                                     |
+|-----------------|-------|---------------------------------------------------------------------------------------------------------------------------------|
+| `-h`            | Named | Show the help message and exit.                                                                                                 |
+| `-r, --profile` | Named | Optional name of the Synapse profile to create or update in the config file. <br/>If omitted, modifies the `[default]` section. |
 
 ### `set-provenance`
 
@@ -372,15 +376,15 @@ synapse set-provenance [-h] --id syn123 [--name NAME] [--description DESCRIPTION
                        [--used [target [target ...]]] [--executed [target [target ...]]] [--limitSearch projId]
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `--id`              | Named  | Synapse ID of entity whose provenance we are accessing.                   |
-| `--name`            | Named  | Name of the activity that generated the entity.                           |
-| `--description`     | Named  | Description of the activity that generated the entity.                    |
-| `-o, --output`      | Named  | Output the provenance record in JSON format.                              |
-| `--used`            | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived. |
-| `--executed`        | Named  | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |
-| `--limitSearch`     | Named  | Synapse ID of a container such as project or folder to limit search for provenance files. |
+| Name            | Type  | Description                                                                                                                            |
+|-----------------|-------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `--id`          | Named | Synapse ID of entity whose provenance we are accessing.                                                                                |
+| `--name`        | Named | Name of the activity that generated the entity.                                                                                        |
+| `--description` | Named | Description of the activity that generated the entity.                                                                                 |
+| `-o, --output`  | Named | Output the provenance record in JSON format.                                                                                           |
+| `--used`        | Named | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) from which the specified entity is derived.         |
+| `--executed`    | Named | Synapse ID, a url, or a local file path (of a file previously uploaded to Synapse) that was executed to generate the specified entity. |
+| `--limitSearch` | Named | Synapse ID of a container such as project or folder to limit search for provenance files.                                              |
 
 
 ### `get-provenance`
@@ -391,11 +395,11 @@ Show provenance records.
 synapse get-provenance [-h] --id syn123 [--version version] [-o [OUTPUT_FILE]]
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `--id`              | Named  | Synapse ID of entity whose provenance we are accessing.                   |
-| `--version`         | Named  | Version of Synapse entity whose provenance we are accessing.              |
-| `-o, --output`      | Named  | Output the provenance record in JSON format.                              |
+| Name           | Type  | Description                                                  |
+|----------------|-------|--------------------------------------------------------------|
+| `--id`         | Named | Synapse ID of entity whose provenance we are accessing.      |
+| `--version`    | Named | Version of Synapse entity whose provenance we are accessing. |
+| `-o, --output` | Named | Output the provenance record in JSON format.                 |
 
 
 ### `set-annotations`
@@ -406,11 +410,11 @@ Create annotations records.
 synapse set-annotations [-h] --id syn123 --annotations ANNOTATIONS [-r]
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `--id`              | Named  | Synapse ID of entity whose annotations we are accessing.                  |                       |
-| `--annotations`     | Named  | Annotations to add as a JSON formatted string, should evaluate to a dictionary (key/value pairs). Example: ‘{“foo”: 1, “bar”:”quux”}’. |                       |
-| `-r, --replace`     | Named  | Replace all existing annotations with the given annotations.               | False                 |
+| Name            | Type  | Description                                                                                                                            | Default |
+|-----------------|-------|----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `--id`          | Named | Synapse ID of entity whose annotations we are accessing.                                                                               |         |
+| `--annotations` | Named | Annotations to add as a JSON formatted string, should evaluate to a dictionary (key/value pairs). Example: ‘{“foo”: 1, “bar”:”quux”}’. |         |
+| `-r, --replace` | Named | Replace all existing annotations with the given annotations.                                                                           | False   |
 
 
 ### `get-annotations`
@@ -421,10 +425,10 @@ Show annotations records.
 synapse get-annotations [-h] --id syn123 [-o [OUTPUT_FILE]]
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `--id`              | Named  | Synapse ID of entity whose annotations we are accessing.                  |
-| `-o, --output`      | Named  | Output the annotations record in JSON format.                             |
+| Name           | Type  | Description                                              |
+|----------------|-------|----------------------------------------------------------|
+| `--id`         | Named | Synapse ID of entity whose annotations we are accessing. |
+| `-o, --output` | Named | Output the annotations record in JSON format.            |
 
 
 ### `create`
@@ -435,13 +439,13 @@ Creates folders or projects on Synapse.
 synapse create [-h] [--parentid syn123] --name NAME [--description DESCRIPTION | --descriptionFile DESCRIPTION_FILE_PATH] type
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `type`              | Positional | Type of object to create in synapse one of {Project, Folder}.             |
-| `--parentid, --parentId` | Named  | Synapse ID of project or folder where to place folder [not used with project]. |
-| `--name`            | Named  | Name of folder/project.                                                   |
-| `--description`     | Named  | Description of project/folder.                                            |
-| `--descriptionFile` | Named  | Path to a markdown file containing description of project/folder.         |
+| Name                     | Type       | Description                                                                    |
+|--------------------------|------------|--------------------------------------------------------------------------------|
+| `type`                   | Positional | Type of object to create in synapse one of {Project, Folder}.                  |
+| `--parentid, --parentId` | Named      | Synapse ID of project or folder where to place folder [not used with project]. |
+| `--name`                 | Named      | Name of folder/project.                                                        |
+| `--description`          | Named      | Description of project/folder.                                                 |
+| `--descriptionFile`      | Named      | Path to a markdown file containing description of project/folder.              |
 
 
 ### `store-table`
@@ -452,11 +456,11 @@ Creates a Synapse Table given a csv.
 synapse store-table [-h] --name NAME [--parentid syn123] [--csv foo.csv]
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `--name`            | Named  | Name of Table.                                                            |
-| `--parentid, --parentId` | Named  | Synapse ID of project.                                                    |
-| `--csv`             | Named  | Path to csv.                                                              |
+| Name                     | Type  | Description            |
+|--------------------------|-------|------------------------|
+| `--name`                 | Named | Name of Table.         |
+| `--parentid, --parentId` | Named | Synapse ID of project. |
+| `--csv`                  | Named | Path to csv.           |
 
 
 ### `onweb`
@@ -467,9 +471,9 @@ Opens Synapse website for Entity.
 synapse onweb [-h] id
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `id`                | Positional | Synapse id.                                                               |
+| Name | Type       | Description |
+|------|------------|-------------|
+| `id` | Positional | Synapse id. |
 
 
 ### `login`
@@ -478,14 +482,14 @@ Verify credentials can be used to login to Synapse.
 This does not need to be used prior to executing other commands.
 
 ```bash
-synapse login [-h] [-u SYNAPSEUSER] [-p SYNAPSE_AUTH_TOKEN] [--profile PROFILE_NAME]
+synapse --profile PROFILE_NAME login [-h] [-u SYNAPSEUSER] [-p SYNAPSE_AUTH_TOKEN]
 ```
 
-| Name             | Type    | Description                                                                | Default               |
-|------------------|---------|----------------------------------------------------------------------------|-----------------------|
-| `-u, --username` | Named  | Username used to connect to Synapse.                                       |                       |
-| `-p, --password` | Named  | Synapse Auth Token (aka: Personal Access Token) used to connect to Synapse |                       |
-| `-r, --profile`  | Named  | Name of the Synapse profile (from .synapseConfig) to log in under          |                       |
+| Name             | Type  | Description                                                                | Default |
+|------------------|-------|----------------------------------------------------------------------------|---------|
+| `-u, --username` | Named | Username used to connect to Synapse.                                       |         |
+| `-p, --password` | Named | Synapse Auth Token (aka: Personal Access Token) used to connect to Synapse |         |
+| `-r, --profile`  | Named | Name of the Synapse profile (from .synapseConfig) to log in under          |         |
 
 If --profile is provided, the credentials will be validated and the login will be associated with the given profile.
 If no profile is specified, the default '[default]' section in ~/.synapseConfig will be used.
@@ -498,9 +502,9 @@ Test character encoding to help diagnose problems.
 synapse test-encoding [-h]
 ```
 
-| Name                | Type    | Description                                                               |
-|---------------------|---------|---------------------------------------------------------------------------|
-| `-h`                | Named  | Show the help message and exit.                                           |
+| Name | Type  | Description                     |
+|------|-------|---------------------------------|
+| `-h` | Named | Show the help message and exit. |
 
 
 ### `get-sts-token`
@@ -511,11 +515,11 @@ Get an STS token for access to AWS S3 storage underlying Synapse.
 synapse get-sts-token [-h] [-o {json,boto,shell,bash,cmd,powershell}] id {read_write,read_only}
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `id`                | Positional | Synapse id.                                                               |                       |
-| `permission`        | Positional | Possible choices: read_write, read_only.                                 |                       |
-| `-o, --output`      | Named  | Possible choices: json, boto, shell, bash, cmd, powershell.               | "shell"               |
+| Name           | Type       | Description                                                 | Default |
+|----------------|------------|-------------------------------------------------------------|---------|
+| `id`           | Positional | Synapse id.                                                 |         |
+| `permission`   | Positional | Possible choices: read_write, read_only.                    |         |
+| `-o, --output` | Named      | Possible choices: json, boto, shell, bash, cmd, powershell. | "shell" |
 
 ### `migrate`
 
@@ -528,15 +532,15 @@ synapse migrate [-h] [--source_storage_location_ids [SOURCE_STORAGE_LOCATION_IDS
                 id dest_storage_location_id db_path
 ```
 
-| Name                | Type    | Description                                                               | Default               |
-|---------------------|---------|---------------------------------------------------------------------------|-----------------------|
-| `id`                | Positional | Synapse id.                                                               |                       |
-| `dest_storage_location_id` | Positional | Destination Synapse storage location id.                                 |                       |
-| `db_path`           | Positional | Local system path where a record keeping file can be stored.              |                       |
-| `--source_storage_location_ids` | Named  | Source Synapse storage location ids. If specified only files in these storage locations will be migrated. |                       |
-| `--file_version_strategy` | Named  | One of ‘new’, ‘latest’, ‘all’, ‘skip’. New creates a new version of each entity, latest migrates the most recent version, all migrates all versions, skip avoids migrating file entities (use when exclusively targeting table attached files. | "new"               |
-| `--include_table_files` | Named  | Include table attached files when migrating.                              | False                 |
-| `--continue_on_error` | Named  | Whether to continue processing other entities if migration of one fails.  | False                 |
-| `--csv_log_path`    | Named  | Path where to log a csv documenting the changes from the migration.       |                       |
-| `--dryRun`          | Named  | Dry run, files will be indexed by not migrated.                           | False                 |
-| `--force`           | Named  | Bypass interactive prompt confirming migration.                           | False                 |
+| Name                            | Type       | Description                                                                                                                                                                                                                                    | Default |
+|---------------------------------|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `id`                            | Positional | Synapse id.                                                                                                                                                                                                                                    |         |
+| `dest_storage_location_id`      | Positional | Destination Synapse storage location id.                                                                                                                                                                                                       |         |
+| `db_path`                       | Positional | Local system path where a record keeping file can be stored.                                                                                                                                                                                   |         |
+| `--source_storage_location_ids` | Named      | Source Synapse storage location ids. If specified only files in these storage locations will be migrated.                                                                                                                                      |         |
+| `--file_version_strategy`       | Named      | One of ‘new’, ‘latest’, ‘all’, ‘skip’. New creates a new version of each entity, latest migrates the most recent version, all migrates all versions, skip avoids migrating file entities (use when exclusively targeting table attached files. | "new"   |
+| `--include_table_files`         | Named      | Include table attached files when migrating.                                                                                                                                                                                                   | False   |
+| `--continue_on_error`           | Named      | Whether to continue processing other entities if migration of one fails.                                                                                                                                                                       | False   |
+| `--csv_log_path`                | Named      | Path where to log a csv documenting the changes from the migration.                                                                                                                                                                            |         |
+| `--dryRun`                      | Named      | Dry run, files will be indexed by not migrated.                                                                                                                                                                                                | False   |
+| `--force`                       | Named      | Bypass interactive prompt confirming migration.                                                                                                                                                                                                | False   |

--- a/synapseclient/api/configuration_services.py
+++ b/synapseclient/api/configuration_services.py
@@ -78,8 +78,7 @@ def get_client_authenticated_s3_profile(
 
 
 def get_config_authentication(
-    config_path: str,
-    profile: str = "default"
+    config_path: str, profile: str = "default"
 ) -> Dict[str, str]:
     """
     Get the authentication section of the configuration file.
@@ -100,12 +99,18 @@ def get_config_authentication(
     )
 
     if section_for_profile:
-        return section_for_profile
+        return {
+            "section_name": profile,
+            **section_for_profile,
+        }
 
-    return get_config_section_dict(
-        section_name=config_file_constants.AUTHENTICATION_SECTION_NAME,
-        config_path=config_path,
-    )
+    return {
+        "section_name": config_file_constants.AUTHENTICATION_SECTION_NAME,
+        **get_config_section_dict(
+            section_name=config_file_constants.AUTHENTICATION_SECTION_NAME,
+            config_path=config_path,
+        ),
+    }
 
 
 def get_transfer_config(

--- a/synapseclient/client.py
+++ b/synapseclient/client.py
@@ -823,11 +823,13 @@ class Synapse(object):
         # Make sure to invalidate the existing session
         self.logout()
 
-        user_login_args = UserLoginArgs(profile=profile, username=email, auth_token=authToken)
+        user_login_args = UserLoginArgs(
+            profile=profile, username=email, auth_token=authToken
+        )
         credential_provider_chain = get_default_credential_chain()
         self.credentials = credential_provider_chain.get_credentials(
-            syn=self,
-            user_login_args=user_login_args)
+            syn=self, user_login_args=user_login_args
+        )
 
         # Final check on login success
         if not self.credentials:
@@ -839,10 +841,16 @@ class Synapse(object):
 
         if not silent:
             display_name = self.credentials.displayname or self.credentials.username
-            if not profile or profile.lower() == config_file_constants.AUTHENTICATION_SECTION_NAME:
+            if (
+                not self.credentials.profile_name
+                or self.credentials.profile_name.lower()
+                == config_file_constants.AUTHENTICATION_SECTION_NAME
+            ):
                 self.logger.info(f"Welcome, {display_name}!\n")
             else:
-                self.logger.info(f"Welcome, {display_name}! You are using the '{profile}' profile.")
+                self.logger.info(
+                    f"Welcome, {display_name}! You are using the '{self.credentials.profile_name}' profile."
+                )
 
     @deprecated(
         version="4.4.0",

--- a/synapseclient/core/credentials/cred_data.py
+++ b/synapseclient/core/credentials/cred_data.py
@@ -1,9 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Optional
 import abc
 import base64
 import json
 import typing
+from dataclasses import dataclass, field
+from typing import Optional
 
 import requests.auth
 
@@ -25,6 +25,11 @@ class SynapseCredentials(requests.auth.AuthBase, abc.ABC):
     @abc.abstractmethod
     def owner_id(self) -> None:
         """The owner id, or profile id, associated with these credentials."""
+
+    @property
+    @abc.abstractmethod
+    def profile_name(self) -> None:
+        """The name of the profile used to find these credentials. May be None."""
 
 
 class SynapseAuthTokenCredentials(SynapseCredentials):
@@ -109,6 +114,15 @@ class SynapseAuthTokenCredentials(SynapseCredentials):
         """The bearer token."""
         return self._token
 
+    @property
+    def profile_name(self) -> str:
+        """The name of the profile used to find these credentials."""
+        return self._profile_name
+
+    @profile_name.setter
+    def profile_name(self, profile_name: str) -> None:
+        self._profile_name = profile_name
+
     def __call__(self, r):
         r.headers.update({"Authorization": f"Bearer {self.secret}"})
         return r
@@ -121,6 +135,7 @@ class SynapseAuthTokenCredentials(SynapseCredentials):
             f"token='{self.secret}', "
             f"owner_id='{self.owner_id}')"
         )
+
 
 @dataclass
 class UserLoginArgs:
@@ -135,6 +150,9 @@ class UserLoginArgs:
         auth_token (Optional[str]): The authentication token for logging in.
                                     Hidden from debug logs for security.
     """
+
     profile: Optional[str] = field(default="default")
     username: Optional[str] = field(default=None)
-    auth_token: Optional[str] = field(default=None, repr=False)  # Hide auth_token from debug logs
+    auth_token: Optional[str] = field(
+        default=None, repr=False
+    )  # Hide auth_token from debug logs


### PR DESCRIPTION
# **Problem:**

- The current authentication system in the Synapse Python Client doesn't consistently track and display which profile is being used for authentication.
- When users log in with a specific profile, there's no clear indication in the welcome message about which profile was actually used.
- The credentials system lacks a standardized way to track profile information throughout the authentication flow.

# **Solution:**

- Added a `profile_name` property to the `SynapseCredentials` abstract class to standardize profile tracking.
- Implemented the `profile_name` property in `SynapseAuthTokenCredentials` to store profile information.
- Updated the `ConfigFileCredentialsProvider` to properly pass the profile name to the credentials object.
- Modified the welcome message in `client.py` to display which profile is being used when a user logs in.
- Ensured consistent profile name handling between the command line client and the Python client.
- Fixed error handling to provide clearer messages when a profile doesn't exist.

**Notes:**

1. I removed the support in the command line client to do `synapse config --profile <PROFILE_NAME>`, instead all commands need to specify the `--profile` flag first, like: `synapse --profile <PROFILE_NAME> config`. The reason for this change is because when flags were in both the root command and the sub-command it was causing data to be wiped out ie `None` in the Python string. Keeping it in a single spot provided consistency across the board. We can look to expand usage later on if this is problematic.

# **Testing:**

- Tested login functionality with various profile configurations to ensure the correct profile information is displayed.
- Verified backward compatibility with existing code that doesn't explicitly use profiles.
- Tested the command line interface to ensure it properly displays profile information during login.
- Confirmed error messages are clear and helpful when users attempt to use non-existent profiles.


**TODO:**

- [x] Update unit/integration tests to ensure and verify the logic/functionality - Perhaps @carmmmm this could be the last thing to tackle on the changes once this is merged into your fork